### PR TITLE
Fix edge case in score calculation of CVSS3

### DIFF
--- a/cvss3/score.go
+++ b/cvss3/score.go
@@ -58,7 +58,7 @@ func (v Vector) Score() float64 {
 // BaseScore returns base score of the vector
 func (v Vector) BaseScore() float64 {
 	i, e := v.impactScore(), v.exploitabilityScore()
-	if i < 0 {
+	if i <= 0 {
 		return 0
 	}
 	c := 1.0
@@ -98,7 +98,7 @@ func (v Vector) TemporalScore() float64 {
 // EnvironmentalScore returns environmental score of the vector
 func (v Vector) EnvironmentalScore() float64 {
 	i, e := v.modifiedImpactScore(), v.modifiedExploitabilityScore()
-	if i < 0 {
+	if i <= 0 {
 		return 0
 	}
 	c := 1.0

--- a/cvss3/score_test.go
+++ b/cvss3/score_test.go
@@ -160,3 +160,36 @@ func TestScoresV30V31(t *testing.T) {
 		}
 	}
 }
+
+func TestScoresZeroImpact(t *testing.T) {
+	vec := "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
+
+	// If we have impact of 0 and exploitability of e.g. 3.9, the overall score must still be 0.
+	// According to https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator/:
+	// The Base Score is a function of the Impact and Exploitability sub score equations. Where the Base score is defined as,
+	//    If (Impact sub score <= 0)     0 else,
+	//    ...
+	for _, c := range []struct {
+		ver                           version
+		base, temporal, environmental float64
+	}{
+		{version(0), 0, 0, 0},
+		{version(1), 0, 0, 0},
+	} {
+		fullVec := fmt.Sprintf("%s%s/%s", prefix, c.ver, vec)
+		v, err := VectorFromString(fullVec)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if base := v.BaseScore(); base != c.base {
+			t.Fatalf("v %s: base score wrong: have %.1f, want %.1f", c.ver, base, c.base)
+		}
+		if temporal := v.TemporalScore(); temporal != c.temporal {
+			t.Fatalf("v %s: temporal score wrong: have %.1f, want %.1f", c.ver, temporal, c.temporal)
+		}
+		if environmental := v.EnvironmentalScore(); environmental != c.environmental {
+			t.Fatalf("v %s: environmental score wrong: have %.1f, want %.1f", c.ver, environmental, c.environmental)
+		}
+	}
+}


### PR DESCRIPTION
This fixes an edge case in which CVSS3 scores are calculated incorrectly if the impact score/modified impact score is 0. E.g. if the impact score is 0 and exploitability 3.9 the overall base score must be 0. 

According to https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator/:
```
The Base Score is a function of the Impact and Exploitability sub score equations. Where the Base score is defined as,

    If (Impact sub score <= 0)     0 else,
    Scope Unchanged4                 𝑅𝑜𝑢𝑛𝑑𝑢𝑝(𝑀𝑖𝑛𝑖𝑚𝑢𝑚[(𝐼𝑚𝑝𝑎𝑐𝑡 + 𝐸𝑥𝑝𝑙𝑜𝑖𝑡𝑎𝑏𝑖𝑙𝑖𝑡𝑦), 10])
    Scope Changed                      𝑅𝑜𝑢𝑛𝑑𝑢𝑝(𝑀𝑖𝑛𝑖𝑚𝑢𝑚[1.08 × (𝐼𝑚𝑝𝑎𝑐𝑡 + 𝐸𝑥𝑝𝑙𝑜𝑖𝑡𝑎𝑏𝑖𝑙𝑖𝑡𝑦), 10])
```
```
The environmental score is defined as,

    If (Modified Impact Sub score <= 0)     0 else,
...
```